### PR TITLE
Actions as a generalization

### DIFF
--- a/ctn_benchmark/benchmark.py
+++ b/ctn_benchmark/benchmark.py
@@ -35,7 +35,9 @@ class _ActionInvoker(object):
 
     @property
     def params(self):
-        return self.action.f_params(self.instance)
+        ps = ParameterSet()
+        self.action.f_params(self.instance, ps)
+        return ps
 
     @property
     def all_params(self):

--- a/ctn_benchmark/benchmark.py
+++ b/ctn_benchmark/benchmark.py
@@ -130,7 +130,7 @@ def parse_args(action_class, default=None, argv=None):
 
     args = parser.parse_args(args=argv)
     p = getattr(action_class, args.action).all_params
-    for k in p:
+    for k in p.flatten():
         p[k] = getattr(args, k)
     return getattr(action_class, args.action), p
 

--- a/ctn_benchmark/benchmark.py
+++ b/ctn_benchmark/benchmark.py
@@ -299,18 +299,6 @@ class NengoBenchmark(Benchmark2):
         pass
 
     @Action
-    def _evaluate(self, p, _sim):
-        self.start_time = time.time()
-        results = self.evaluate(p, _sim)
-        if hasattr(_sim, 'close'):
-            _sim.close()
-        return results
-
-    @_evaluate.params
-    def _evaluate(self, ps):
-        self.evaluate_params(ps)
-
-    @Action
     def _sim(self, p, _model):
         module = importlib.import_module(p.backend)
         Simulator = module.Simulator

--- a/ctn_benchmark/benchmark.py
+++ b/ctn_benchmark/benchmark.py
@@ -37,9 +37,6 @@ class _ActionInvoker(object):
     def name(self):
         return self.action.name
 
-    def impl(self, f_action):
-        return self.action.impl(f_action)
-
     @property
     def dependencies(self):
         args = inspect.getargspec(self.action.f_action).args
@@ -63,28 +60,6 @@ class _ActionInvoker(object):
         return ps
 
 
-class AbstractAction(object):
-    def __init__(self, name, pre=None, post=None):
-        self.name = name
-        self.f_pre = pre
-        self.f_post = post
-
-    def __call__(self, *args, **kwargs):
-        raise NotImplementedError()
-
-    def impl(self, f_action):
-        return Action(
-            f_action, pre=self.f_pre, post=self.f_post, name=self.name)
-
-    def pre(self, f_pre):
-        self.f_pre = f_pre
-        return self
-
-    def post(self, f_post):
-        self.f_post = f_post
-        return self
-
-
 class Action(object):
     def __init__(
             self, f_action, f_params=None, pre=None, post=None, name=None):
@@ -103,10 +78,6 @@ class Action(object):
         self.name = name
         self.results = WeakKeyDictionary()
 
-    def impl(self, f_action):
-        self.f_action = f_action
-        return self
-
     def params(self, f_params):
         self.f_params = f_params
         return self
@@ -121,13 +92,6 @@ class Action(object):
 
     def __get__(self, instance, owner):
         return _ActionInvoker(instance, self)
-
-
-class OptionalAction(Action):
-    def __init__(self, name, f_params=None, pre=None, post=None):
-        super(OptionalAction, self).__init__(
-            lambda inst, p: None, f_params=f_params, pre=pre, post=post,
-            name=name)
 
 
 def gather_actions(action_class):

--- a/ctn_benchmark/benchmark.py
+++ b/ctn_benchmark/benchmark.py
@@ -27,6 +27,10 @@ class _ActionInvoker(object):
             **{k: v(p) for k, v in self.dependencies.items()})
 
     @property
+    def name(self):
+        return self.action.name
+
+    @property
     def dependencies(self):
         args = inspect.getargspec(self.action.f_action).args
         dependencies = {}
@@ -55,7 +59,7 @@ class Action(object):
             name = f_action.__name__
         self.f_action = f_action
         if f_params is None:
-            f_params = lambda inst: ParameterSet()
+            f_params = lambda inst, ps: ps
         self.f_params = f_params
         self.name = name
 
@@ -70,108 +74,99 @@ class Action(object):
 def gather_actions(action_class):
     for attr_name in dir(action_class):
         attr = getattr(action_class, attr_name)
-        if isinstance(attr, _ActionInvoker):
+        if isinstance(attr, _ActionInvoker) and not attr_name.startswith('_'):
             yield attr_name, attr
 
 
-def cmd_run_actions(action_class, default=None, argv=None):
+def parse_args(action_class, default=None, argv=None):
     if argv is None:
         argv = sys.argv[1:]
 
     # TODO provide useful description to parser
     parser = argparse.ArgumentParser()
     action_parsers = parser.add_subparsers(dest='action')
-    actions = gather_actions(action_class)
+    actions = list(gather_actions(action_class))
 
-    if default is not None:
-        if len(argv) < 1 or argv[1] not in [a[0] for a in actions]:
+    help_flag = '-h' in argv or '--help' in argv
+    if default is not None and not help_flag:
+        if len(argv) < 1 or argv[0] not in [a[0] for a in actions]:
             argv.insert(0, default)
 
-    for attr_name in dir(action_class):
-        attr = getattr(action_class, attr_name)
-        if isinstance(attr, _ActionInvoker):
-            action_parser = action_parsers.add_parser(attr_name)
-            to_argparser(attr.all_params, action_parser)
+    for attr_name, attr in actions:
+        action_parser = action_parsers.add_parser(attr_name)
+        to_argparser(attr.all_params, action_parser)
 
     args = parser.parse_args(args=argv)
-    return getattr(action_class, args.action)(args)
+    p = getattr(action_class, args.action).all_params
+    for k in p:
+        p[k] = getattr(args, k)
+    return getattr(action_class, args.action), p
 
 
 class Benchmark(object):
     def __init__(self):
         self.parameters = ParameterSet()
-        self.hidden_params = []
-        self.fixed_params()
+        self.hidden_params = [
+            'data_dir', 'show_figs', 'debug', 'save_raw', 'save_figs',
+            'save_results']
         self.params()
+
+    def model(self, p):
+        raise NotImplementedError()
+
+    def evaluate(self, p, sim, plt):
+        raise NotImplementedError()
+
+    def params(self):
+        raise NotImplementedError()
 
     def default(self, description, **kwargs):
         self.parameters.add_default(description, **kwargs)
-
-    def fixed_params(self):
-        self.default('backend to use', backend='nengo')
-        self.default('time step', dt=0.001)
-        self.default('random number seed', seed=1)
-        self.default('data directory', data_dir='data')
-        self.default('display figures', show_figs=False)
-        self.default('enable debug messages', debug=False)
-        self.default('save raw data', save_raw=False)
-        self.default('save figures', save_figs=False)
-        self.default('hide overlay on figures', hide_overlay=False)
-        self.default('save results', save_results=False)
-        self.default('use nengo_gui', gui=False)
-        self.hidden_params.extend(['data_dir', 'show_figs', 'debug',
-                                   'save_raw', 'save_figs', 'save_results'])
-
-    def process_args(self, allow_cmdline=True, **kwargs):
-        param_parser = argparse.ArgumentParser(
-                parents=[to_argparser(self.parameters)],
-                description="Nengo benchmark: " + self.__class__.__name__)
-
-        if len(kwargs) == 0 and allow_cmdline:
-            args = param_parser.parse_args()
-        else:
-            args = argparse.Namespace()
-            for k in self.parameters:
-                v = kwargs.get(k, param_parser.get_default(k))
-                setattr(args, k, v)
-
-        name = self.__class__.__name__
-        self.args_text = []
-        for k in self.parameters:
-            if k not in self.hidden_params:
-                self.args_text.append('_%s = %r' % (k, getattr(args, k)))
-
-        uid = np.random.randint(0x7FFFFFFF)
-        filename = name + '#' + time.strftime('%Y%m%d-%H%M%S')+('-%08x' % uid)
-
-        return args, filename
-
-    def make_model(self, **kwargs):
-        p, fn = self.process_args(allow_cmdline=False, **kwargs)
-        np.random.seed(p.seed)
-        model = self.model(p)
-        return model
 
     def record_speed(self, t):
         now = time.time()
         self.sim_speed = t / (now - self.start_time)
 
-    def run(self, **kwargs):
-        p, fn = self.process_args(**kwargs)
+    @Action
+    def filename(self, p):
+        name = self.__class__.__name__
+        uid = np.random.randint(0x7FFFFFFF)
+        filename = name + '#' + time.strftime('%Y%m%d-%H%M%S')+('-%08x' % uid)
+        return filename
+
+    @Action
+    def _setup(self, p, filename):
         if p.debug:
             logging.basicConfig(level=logging.DEBUG)
         else:
             logging.basicConfig(level=logging.ERROR)
-        print('running %s' % fn)
+        print('running %s' % filename)
+
         np.random.seed(p.seed)
 
-        model = self.model(p)
-        if p.gui:
-            import nengo_gui
-            nengo_gui.GUI(model=model, filename=self.__class__.__name__,
-                          locals=dict(model=model), interactive=False,
-                          allow_file_change=False).start()
-            return
+    @_setup.params
+    def _setup(self, ps):
+        ps.add_default('random number seed', seed=1)
+        ps.add_default('enable debug messages', debug=False)
+
+    @Action
+    def _model(self, p, _setup):
+        return self.model(p)
+
+    @_model.params
+    def _model(self, ps):
+        ps.add_parameter_set(self.parameters)
+
+    @Action
+    def gui(self, p, _model):
+        import nengo_gui
+        nengo_gui.GUI(
+            model=_model, filename=self.__class__.__name__,
+            locals=dict(model=_model), interactive=False,
+            allow_file_change=False).start()
+
+    @Action
+    def run_model(self, p, _model, filename):
         module = importlib.import_module(p.backend)
         Simulator = module.Simulator
 
@@ -192,12 +187,12 @@ class Benchmark(object):
             plt.figure()
         else:
             plt = None
-        sim = Simulator(model, dt=p.dt)
+        sim = Simulator(_model, dt=p.dt)
         self.start_time = time.time()
         self.sim_speed = None
         result = self.evaluate(p, sim, plt)
 
-        if p.backend == 'nengo_spinnaker':
+        if hasattr(sim, 'close'):
             sim.close()
 
         if self.sim_speed is not None and 'sim_speed' not in result:
@@ -207,27 +202,31 @@ class Benchmark(object):
         for k, v in sorted(result.items()):
             text.append('%s = %s' % (k, repr(v)))
 
+        args_text = []
+        for k in p:
+            if k not in self.hidden_params:
+                args_text.append('_%s = %r' % (k, getattr(p, k)))
 
         if plt is not None and not p.hide_overlay:
-            plt.suptitle(fn +'\n' + '\n'.join(text),
+            plt.suptitle(filename +'\n' + '\n'.join(text),
                          fontsize=8)
-            plt.figtext(0.13,0.12,'\n'.join(self.args_text))
+            plt.figtext(0.13,0.12,'\n'.join(args_text))
 
-        text = self.args_text + text
+        text = args_text + text
         text = '\n'.join(text)
 
         if not os.path.exists(p.data_dir):
             os.mkdir(p.data_dir)
-        fn = os.path.join(p.data_dir, fn)
+        filename = os.path.join(p.data_dir, filename)
         if p.save_figs:
-            plt.savefig(fn + '.png', dpi=300)
+            plt.savefig(filename + '.png', dpi=300)
 
-        with open(fn + '.txt', 'w') as f:
+        with open(filename + '.txt', 'w') as f:
             f.write(text)
         print(text)
 
         if p.save_raw:
-            db = shelve.open(fn + '.db')
+            db = shelve.open(filename + '.db')
             db['trange'] = sim.trange()
             for k, v in inspect.getmembers(self):
                 if isinstance(v, nengo.Probe):
@@ -237,4 +236,27 @@ class Benchmark(object):
         if p.show_figs:
             plt.show()
 
-        return result
+        return result, filename
+
+    @run_model.params
+    def run_model(self, ps):
+        ps.add_default('backend to use', backend='nengo')
+        ps.add_default('time step', dt=0.001)
+        ps.add_default('data directory', data_dir='data')
+        ps.add_default('display figures', show_figs=False)
+        ps.add_default('save raw data', save_raw=False)
+        ps.add_default('save figures', save_figs=False)
+        ps.add_default('hide overlay on figures', hide_overlay=False)
+
+    def process_args(self, allow_cmdline=True, **kwargs):
+        if allow_cmdline and len(kwargs) == 0:
+            return parse_args(self, default='run_model')
+        else:
+            return self._run_model.params.set(**kwargs)
+
+    def run(self, **kwargs):
+        action, p = self.process_args(**kwargs)
+        return action(p)
+
+    def make_model(self, **kwargs):
+        return self._model(self.process_args(allow_cmdline=False, **kwargs)[1])

--- a/ctn_benchmark/benchmark.py
+++ b/ctn_benchmark/benchmark.py
@@ -223,11 +223,11 @@ class Benchmark2(object):
     def save_figs(self, p, _filename, _figs):
         for i in plt.get_fignums():
             fig = plt.figure(i)
-            fig.savefig(_filename + p.ext, dpi=p.dpi)
+            fig.savefig(_filename + '-' + str(i) + p.ext, dpi=p.dpi)
 
     @save_figs.params
     def save_figs(self, ps):
-        ps.add_default("File extension of saved figures.", fig_ext='.png')
+        ps.add_default("File extension of saved figures.", ext='.png')
         ps.add_default("Resolution of saved figures.", dpi=300)
 
     @Action

--- a/ctn_benchmark/benchmark.py
+++ b/ctn_benchmark/benchmark.py
@@ -25,15 +25,20 @@ class _ActionInvoker(object):
     def __call__(self, p):
         if self.instance in self.action.results:
             return self.action.results[self.instance]
+        self.action.f_pre(self.instance, p)
         result = self.action.f_action(
             self.instance, p,
             **{k: v(p) for k, v in self.dependencies.items()})
         self.action.results[self.instance] = result
+        self.action.f_post(self.instance, p)
         return result
 
     @property
     def name(self):
         return self.action.name
+
+    def impl(self, f_action):
+        return self.action.impl(f_action)
 
     @property
     def dependencies(self):
@@ -58,23 +63,71 @@ class _ActionInvoker(object):
         return ps
 
 
+class AbstractAction(object):
+    def __init__(self, name, pre=None, post=None):
+        self.name = name
+        self.f_pre = pre
+        self.f_post = post
+
+    def __call__(self, *args, **kwargs):
+        raise NotImplementedError()
+
+    def impl(self, f_action):
+        return Action(
+            f_action, pre=self.f_pre, post=self.f_post, name=self.name)
+
+    def pre(self, f_pre):
+        self.f_pre = f_pre
+        return self
+
+    def post(self, f_post):
+        self.f_post = f_post
+        return self
+
+
 class Action(object):
-    def __init__(self, f_action, f_params=None, name=None):
+    def __init__(
+            self, f_action, f_params=None, pre=None, post=None, name=None):
         if name is None:
             name = f_action.__name__
         self.f_action = f_action
         if f_params is None:
             f_params = lambda inst, ps: ps
+        if pre is None:
+            pre = lambda inst, p: None
+        if post is None:
+            post = lambda inst, p: None
         self.f_params = f_params
+        self.f_pre = pre
+        self.f_post = post
         self.name = name
         self.results = WeakKeyDictionary()
+
+    def impl(self, f_action):
+        self.f_action = f_action
+        return self
 
     def params(self, f_params):
         self.f_params = f_params
         return self
 
+    def pre(self, f_pre):
+        self.f_pre = f_pre
+        return self
+
+    def post(self, f_post):
+        self.f_post = f_post
+        return self
+
     def __get__(self, instance, owner):
         return _ActionInvoker(instance, self)
+
+
+class OptionalAction(Action):
+    def __init__(self, name, f_params=None, pre=None, post=None):
+        super(OptionalAction, self).__init__(
+            lambda inst, p: None, f_params=f_params, pre=pre, post=post,
+            name=name)
 
 
 def gather_actions(action_class):

--- a/ctn_benchmark/nengo/communication2.py
+++ b/ctn_benchmark/nengo/communication2.py
@@ -11,7 +11,7 @@ import numpy as np
 
 import ctn_benchmark
 
-class CommunicationChannel(ctn_benchmark.benchmark.Benchmark2):
+class CommunicationChannel(ctn_benchmark.benchmark.NengoBenchmark):
     def model_params(self, ps):
         ps.add_default('number of dimensions', D=2)
         ps.add_default('number of layers', L=2)
@@ -52,9 +52,9 @@ class CommunicationChannel(ctn_benchmark.benchmark.Benchmark2):
         rmse = np.sqrt(np.mean(sim.data[self.probes['pOutput']] - ideal)**2)
         return dict(rmse=rmse, ideal=ideal)
 
-    def plot(self, p, sim, results):
-        plt.plot(sim.trange(), sim.data[self.probes['pOutput']])
-        plt.plot(sim.trange(), results['ideal'])
+    def plot(self, p, results):
+        plt.plot(self.sim.trange(), self.sim.data[self.probes['pOutput']])
+        plt.plot(self.sim.trange(), results['ideal'])
         plt.ylim(-1, 1)
 
 

--- a/ctn_benchmark/nengo/communication2.py
+++ b/ctn_benchmark/nengo/communication2.py
@@ -1,0 +1,62 @@
+"""
+Nengo Benchmark Model: Communication Channel
+
+Input: Randomly chosen D-dimensional value
+Ouput: the same value as the input
+"""
+
+import matplotlib.pyplot as plt
+import nengo
+import numpy as np
+
+import ctn_benchmark
+
+class CommunicationChannel(ctn_benchmark.benchmark.Benchmark2):
+    def model_params(self, ps):
+        ps.add_default('number of dimensions', D=2)
+        ps.add_default('number of layers', L=2)
+        ps.add_default('number of neurons per layer', N=100)
+        ps.add_default('synaptic time constant', pstc=0.01)
+
+    def model(self, p):
+        model = nengo.Network()
+        with model:
+            value = np.random.randn(p.D)
+            value /= np.linalg.norm(value)
+
+            input = nengo.Node(value)
+
+            layers = [nengo.Ensemble(p.N, p.D) for i in range(p.L)]
+
+            nengo.Connection(input, layers[0])
+            for i in range(p.L-1):
+                nengo.Connection(layers[i], layers[i+1], synapse=p.pstc)
+
+            self.add_probes(
+                pInput=nengo.Probe(input),
+                pOutput=nengo.Probe(layers[-1], synapse=p.pstc))
+        return model
+
+
+    def evaluate_params(self, ps):
+        ps.add_default('simulation time', T=1.0)
+
+    def evaluate(self, p, sim):
+        sim.run(p.T)
+        self.record_speed(p.T)
+
+        ideal = sim.data[self.probes['pInput']]
+        for i in range(p.L):
+            ideal = nengo.synapses.filt(ideal, nengo.Lowpass(p.pstc), p.dt)
+
+        rmse = np.sqrt(np.mean(sim.data[self.probes['pOutput']] - ideal)**2)
+        return dict(rmse=rmse, ideal=ideal)
+
+    def plot(self, p, sim, results):
+        plt.plot(sim.trange(), sim.data[self.probes['pOutput']])
+        plt.plot(sim.trange(), results['ideal'])
+        plt.ylim(-1, 1)
+
+
+if __name__ == '__main__':
+    CommunicationChannel().main()

--- a/ctn_benchmark/parameters.py
+++ b/ctn_benchmark/parameters.py
@@ -42,6 +42,10 @@ class ParameterSet(MutableMapping):
                 "Parameter {0} already exists.".format(param.name))
         self.params[param.name] = param
 
+    def add_parameter_set(self, parameter_set):
+        for param in parameter_set.params.values():
+            self.add_parameter(param)
+
     def add_default(self, description, param_type=None, **kwargs):
         if len(kwargs) != 1:
             raise ValueError("Must specifiy exactly one parameter.")

--- a/ctn_benchmark/parameters.py
+++ b/ctn_benchmark/parameters.py
@@ -37,15 +37,14 @@ class ParameterSet(MutableMapping):
         super(ParameterSet, self).__setattr__('params', {})
 
     def add_parameter(self, param):
-        # FIXME
-        # if param.name in self.params:
-            # raise ValueError(
-                # "Parameter {0} already exists.".format(param.name))
+        if param.name in self.params:
+            raise ValueError(
+                "Parameter {0} already exists.".format(param.name))
         self.params[param.name] = param
 
-    def add_parameter_set(self, parameter_set):
+    def merge_parameter_set(self, parameter_set):
         for param in parameter_set.params.values():
-            self.add_parameter(param)
+            self.params[param.name] = param
 
     def add_default(self, description, param_type=None, **kwargs):
         if len(kwargs) != 1:

--- a/ctn_benchmark/parameters.py
+++ b/ctn_benchmark/parameters.py
@@ -77,8 +77,10 @@ class ParameterSet(MutableMapping):
         for k, v in kwargs.items():
             self[k] = v
 
-def to_argparser(parameter_set):
-    parser = argparse.ArgumentParser(add_help=False)
+
+def to_argparser(parameter_set, parser=None):
+    if parser is None:
+        parser = argparse.ArgumentParser(add_help=False)
     for v in parameter_set.params.values():
         if v.default is True:
             parser.add_argument(

--- a/ctn_benchmark/parameters.py
+++ b/ctn_benchmark/parameters.py
@@ -103,7 +103,7 @@ class ParameterSet(MutableMapping):
 
 def to_argparser(parameter_set, parser=None, prefix=''):
     if parser is None:
-        parser = argparse.ArgumentParser(add_help=False)
+        parser = argparse.ArgumentParser()
     for v in parameter_set.params.values():
         if v.default is True:
             parser.add_argument(

--- a/ctn_benchmark/parameters.py
+++ b/ctn_benchmark/parameters.py
@@ -37,9 +37,10 @@ class ParameterSet(MutableMapping):
         super(ParameterSet, self).__setattr__('params', {})
 
     def add_parameter(self, param):
-        if param.name in self.params:
-            raise ValueError(
-                "Parameter {0} already exists.".format(param.name))
+        # FIXME
+        # if param.name in self.params:
+            # raise ValueError(
+                # "Parameter {0} already exists.".format(param.name))
         self.params[param.name] = param
 
     def add_parameter_set(self, parameter_set):

--- a/ctn_benchmark/parameters.py
+++ b/ctn_benchmark/parameters.py
@@ -73,6 +73,9 @@ class ParameterSet(MutableMapping):
     def __setattr__(self, name, value):
         self[name] = value
 
+    def set(self, **kwargs):
+        for k, v in kwargs.items():
+            self[k] = v
 
 def to_argparser(parameter_set):
     parser = argparse.ArgumentParser(add_help=False)

--- a/ctn_benchmark/tests/test_benchmark.py
+++ b/ctn_benchmark/tests/test_benchmark.py
@@ -64,7 +64,7 @@ class TestAction(object):
         assert inst.dependent_action.all_params.bar == 42
 
 
-class TestCmdRunActions(object):
+class TestParseArgs(object):
     class ActionClass(object):
         @benchmark.Action
         def dummy_action(self, p):
@@ -75,16 +75,24 @@ class TestCmdRunActions(object):
             ps.add_default("foo", foo=42)
 
     def test_invoke_action(self):
-        assert benchmark.cmd_run_actions(
-            self.ActionClass(), argv=['dummy_action']) == 42
+        action, p = benchmark.parse_args(
+            self.ActionClass(), argv=['dummy_action'])
+        assert action.name == 'dummy_action'
+        assert p.foo == 42
 
     def test_set_parameter(self):
-        assert benchmark.cmd_run_actions(
-            self.ActionClass(), argv=['dummy_action', '--foo', '23']) == 23
+        action, p = benchmark.parse_args(
+            self.ActionClass(), argv=['dummy_action', '--foo', '23'])
+        assert action.name == 'dummy_action'
+        assert p.foo == 23
 
     def test_invoke_default(self):
-        assert benchmark.cmd_run_actions(
-            self.ActionClass(), default='dummy_action', argv=[]) == 42
-        assert benchmark.cmd_run_actions(
-            self.ActionClass(), default='dummy_action',
-            argv=['--foo', '23']) == 23
+        action, p = benchmark.parse_args(
+            self.ActionClass(), default='dummy_action', argv=[])
+        assert action.name == 'dummy_action'
+        assert p.foo == 42
+
+        action, p = benchmark.parse_args(
+            self.ActionClass(), default='dummy_action', argv=['--foo', '23'])
+        assert action.name == 'dummy_action'
+        assert p.foo == 23

--- a/ctn_benchmark/tests/test_benchmark.py
+++ b/ctn_benchmark/tests/test_benchmark.py
@@ -1,3 +1,5 @@
+import pytest
+
 from ctn_benchmark import benchmark, parameters
 
 
@@ -76,6 +78,106 @@ class TestAction(object):
         inst.dummy_action(parameters.ParameterSet())
         inst.dummy_action(parameters.ParameterSet())
         assert inst.n_calls == 1
+
+    def test_pre_and_post_methods(self):
+        class ActionClass(object):
+            def __init__(self):
+                self.pre_called = False
+                self.action_called = False
+                self.post_called = False
+
+            @benchmark.Action
+            def dependency(self, p):
+                assert self.pre_called
+
+            @benchmark.Action
+            def dummy_action(self, p, dependency):
+                assert self.pre_called
+                self.action_called = True
+
+            @dummy_action.pre
+            def dummy_action(self, p):
+                self.pre_called = True
+
+            @dummy_action.post
+            def dummy_action(self, p):
+                assert self.action_called
+                self.post_called = True
+
+        inst = ActionClass()
+        inst.dummy_action(parameters.ParameterSet())
+        assert inst.post_called
+
+    def test_abstract_action(self):
+        class BaseActionClass(object):
+            def __init__(self):
+                self.pre_called = False
+                self.action_called = False
+                self.post_called = False
+
+            dummy_action = benchmark.AbstractAction('dummy_action')
+
+            @dummy_action.pre
+            def dummy_action(self, p):
+                self.pre_called = True
+
+            @dummy_action.post
+            def dummy_action(self, p):
+                assert self.action_called
+                self.post_called = True
+
+
+        class ActionClass(BaseActionClass):
+            @BaseActionClass.dummy_action.impl
+            def dummy_action(self, p):
+                assert self.pre_called
+                self.action_called = True
+
+        base = BaseActionClass()
+        with pytest.raises(NotImplementedError):
+            base.dummy_action(parameters.ParameterSet())
+        assert not base.pre_called
+        assert not base.post_called
+
+        inst = ActionClass()
+        inst.dummy_action(parameters.ParameterSet())
+        assert inst.action_called
+        assert inst.post_called
+
+    def test_optional_action(self):
+        class BaseActionClass(object):
+            def __init__(self):
+                self.pre_called = False
+                self.action_called = False
+                self.post_called = False
+
+            dummy_action = benchmark.OptionalAction('dummy_action')
+
+            @dummy_action.pre
+            def dummy_action(self, p):
+                self.pre_called = True
+
+            @dummy_action.post
+            def dummy_action(self, p):
+                assert self.action_called
+                self.post_called = True
+
+
+        class ActionClass(BaseActionClass):
+            @BaseActionClass.dummy_action.impl
+            def dummy_action(self, p):
+                assert self.pre_called
+                self.action_called = True
+
+        base = BaseActionClass()
+        base.dummy_action(parameters.ParameterSet())
+        assert base.pre_called
+        assert base.post_called
+
+        inst = ActionClass()
+        inst.dummy_action(parameters.ParameterSet())
+        assert inst.action_called
+        assert inst.post_called
 
 
 class TestParseArgs(object):

--- a/ctn_benchmark/tests/test_benchmark.py
+++ b/ctn_benchmark/tests/test_benchmark.py
@@ -1,5 +1,3 @@
-import pytest
-
 from ctn_benchmark import benchmark, parameters
 
 
@@ -106,77 +104,6 @@ class TestAction(object):
 
         inst = ActionClass()
         inst.dummy_action(parameters.ParameterSet())
-        assert inst.post_called
-
-    def test_abstract_action(self):
-        class BaseActionClass(object):
-            def __init__(self):
-                self.pre_called = False
-                self.action_called = False
-                self.post_called = False
-
-            dummy_action = benchmark.AbstractAction('dummy_action')
-
-            @dummy_action.pre
-            def dummy_action(self, p):
-                self.pre_called = True
-
-            @dummy_action.post
-            def dummy_action(self, p):
-                assert self.action_called
-                self.post_called = True
-
-
-        class ActionClass(BaseActionClass):
-            @BaseActionClass.dummy_action.impl
-            def dummy_action(self, p):
-                assert self.pre_called
-                self.action_called = True
-
-        base = BaseActionClass()
-        with pytest.raises(NotImplementedError):
-            base.dummy_action(parameters.ParameterSet())
-        assert not base.pre_called
-        assert not base.post_called
-
-        inst = ActionClass()
-        inst.dummy_action(parameters.ParameterSet())
-        assert inst.action_called
-        assert inst.post_called
-
-    def test_optional_action(self):
-        class BaseActionClass(object):
-            def __init__(self):
-                self.pre_called = False
-                self.action_called = False
-                self.post_called = False
-
-            dummy_action = benchmark.OptionalAction('dummy_action')
-
-            @dummy_action.pre
-            def dummy_action(self, p):
-                self.pre_called = True
-
-            @dummy_action.post
-            def dummy_action(self, p):
-                assert self.action_called
-                self.post_called = True
-
-
-        class ActionClass(BaseActionClass):
-            @BaseActionClass.dummy_action.impl
-            def dummy_action(self, p):
-                assert self.pre_called
-                self.action_called = True
-
-        base = BaseActionClass()
-        base.dummy_action(parameters.ParameterSet())
-        assert base.pre_called
-        assert base.post_called
-
-        inst = ActionClass()
-        inst.dummy_action(parameters.ParameterSet())
-        assert inst.action_called
         assert inst.post_called
 
 

--- a/ctn_benchmark/tests/test_benchmark.py
+++ b/ctn_benchmark/tests/test_benchmark.py
@@ -24,3 +24,18 @@ class TestAction(object):
 
         inst = ActionClass()
         inst.dependent_action(parameters.ParameterSet())
+
+    def test_allows_to_define_parameters(self):
+        class ActionClass(object):
+            @benchmark.Action
+            def dummy_action(self, p):
+                return p.foo
+
+            @dummy_action.params
+            def dummy_action(self):
+                ps = parameters.ParameterSet()
+                ps.add_default("foo", foo=23)
+                return ps
+
+        inst = ActionClass()
+        assert inst.dummy_action.params.foo == 23

--- a/ctn_benchmark/tests/test_benchmark.py
+++ b/ctn_benchmark/tests/test_benchmark.py
@@ -39,3 +39,32 @@ class TestAction(object):
 
         inst = ActionClass()
         assert inst.dummy_action.params.foo == 23
+        assert inst.dummy_action.all_params.foo == 23
+
+    def test_allows_to_retrieve_all_parameters(self):
+        class ActionClass(object):
+            @benchmark.Action
+            def dependency(self, p):
+                return p.foo
+
+            @dependency.params
+            def dependency(self):
+                ps = parameters.ParameterSet()
+                ps.add_default("foo", foo=23)
+                return ps
+
+            @benchmark.Action
+            def dependent_action(self, p, dependency):
+                return p.bar
+
+            @dependent_action.params
+            def dependent_action(self):
+                ps = parameters.ParameterSet()
+                ps.add_default("bar", bar=42)
+                return ps
+
+        inst = ActionClass()
+        assert 'foo' not in inst.dependent_action.params
+        assert inst.dependent_action.params.bar == 42
+        assert inst.dependent_action.all_params.foo == 23
+        assert inst.dependent_action.all_params.bar == 42

--- a/ctn_benchmark/tests/test_benchmark.py
+++ b/ctn_benchmark/tests/test_benchmark.py
@@ -130,21 +130,24 @@ class TestParseArgs(object):
             ps.add_default("foo", foo=42)
 
     def test_invoke_action(self):
-        action, p = benchmark.parse_args(
+        actions, p = benchmark.parse_args(
             self.ActionClass(), argv=['dummy_action'])
-        assert action.name == 'dummy_action'
+        assert len(actions) == 1
+        assert actions[0].name == 'dummy_action'
         assert p.foo == 42
 
     def test_set_parameter(self):
-        action, p = benchmark.parse_args(
+        actions, p = benchmark.parse_args(
             self.ActionClass(), argv=['dummy_action', '--foo', '23'])
-        assert action.name == 'dummy_action'
+        assert len(actions) == 1
+        assert actions[0].name == 'dummy_action'
         assert p.foo == 23
 
     def test_invoke_default(self):
-        action, p = benchmark.parse_args(
-            self.ActionClass(), default='dummy_action', argv=[])
-        assert action.name == 'dummy_action'
+        actions, p = benchmark.parse_args(
+            self.ActionClass(), default=['dummy_action'], argv=[])
+        assert len(actions) == 1
+        assert actions[0].name == 'dummy_action'
         assert p.foo == 42
 
         action, p = benchmark.parse_args(

--- a/ctn_benchmark/tests/test_benchmark.py
+++ b/ctn_benchmark/tests/test_benchmark.py
@@ -63,6 +63,20 @@ class TestAction(object):
         assert inst.dependent_action.all_params.foo == 23
         assert inst.dependent_action.all_params.bar == 42
 
+    def test_caches_results(self):
+        class ActionClass(object):
+            def __init__(self):
+                self.n_calls = 0
+
+            @benchmark.Action
+            def dummy_action(self, p):
+                self.n_calls += 1
+
+        inst = ActionClass()
+        inst.dummy_action(parameters.ParameterSet())
+        inst.dummy_action(parameters.ParameterSet())
+        assert inst.n_calls == 1
+
 
 class TestParseArgs(object):
     class ActionClass(object):

--- a/ctn_benchmark/tests/test_benchmark.py
+++ b/ctn_benchmark/tests/test_benchmark.py
@@ -62,3 +62,29 @@ class TestAction(object):
         assert inst.dependent_action.params.bar == 42
         assert inst.dependent_action.all_params.foo == 23
         assert inst.dependent_action.all_params.bar == 42
+
+
+class TestCmdRunActions(object):
+    class ActionClass(object):
+        @benchmark.Action
+        def dummy_action(self, p):
+            return p.foo
+
+        @dummy_action.params
+        def dummy_action(self, ps):
+            ps.add_default("foo", foo=42)
+
+    def test_invoke_action(self):
+        assert benchmark.cmd_run_actions(
+            self.ActionClass(), argv=['dummy_action']) == 42
+
+    def test_set_parameter(self):
+        assert benchmark.cmd_run_actions(
+            self.ActionClass(), argv=['dummy_action', '--foo', '23']) == 23
+
+    def test_invoke_default(self):
+        assert benchmark.cmd_run_actions(
+            self.ActionClass(), default='dummy_action', argv=[]) == 42
+        assert benchmark.cmd_run_actions(
+            self.ActionClass(), default='dummy_action',
+            argv=['--foo', '23']) == 23

--- a/ctn_benchmark/tests/test_benchmark.py
+++ b/ctn_benchmark/tests/test_benchmark.py
@@ -81,8 +81,10 @@ class TestAction(object):
         class ActionClass(object):
             def __init__(self):
                 self.pre_called = False
+                self.pre_dep_called = False
                 self.action_called = False
                 self.post_called = False
+                self.post_dep_called = False
 
             @benchmark.Action
             def dependency(self, p):
@@ -94,13 +96,23 @@ class TestAction(object):
                 self.action_called = True
 
             @dummy_action.pre
-            def dummy_action(self, p):
+            def dummy_action(self, p, pre_dep):
+                assert self.pre_dep_called
                 self.pre_called = True
 
             @dummy_action.post
-            def dummy_action(self, p):
+            def dummy_action(self, p, post_dep):
                 assert self.action_called
+                assert self.post_dep_called
                 self.post_called = True
+
+            @benchmark.Action
+            def pre_dep(self, p):
+                self.pre_dep_called = True
+
+            @benchmark.Action
+            def post_dep(self, p):
+                self.post_dep_called = True
 
         inst = ActionClass()
         inst.dummy_action(parameters.ParameterSet())

--- a/ctn_benchmark/tests/test_benchmark.py
+++ b/ctn_benchmark/tests/test_benchmark.py
@@ -32,10 +32,8 @@ class TestAction(object):
                 return p.foo
 
             @dummy_action.params
-            def dummy_action(self):
-                ps = parameters.ParameterSet()
+            def dummy_action(self, ps):
                 ps.add_default("foo", foo=23)
-                return ps
 
         inst = ActionClass()
         assert inst.dummy_action.params.foo == 23
@@ -48,20 +46,16 @@ class TestAction(object):
                 return p.foo
 
             @dependency.params
-            def dependency(self):
-                ps = parameters.ParameterSet()
+            def dependency(self, ps):
                 ps.add_default("foo", foo=23)
-                return ps
 
             @benchmark.Action
             def dependent_action(self, p, dependency):
                 return p.bar
 
             @dependent_action.params
-            def dependent_action(self):
-                ps = parameters.ParameterSet()
+            def dependent_action(self, ps):
                 ps.add_default("bar", bar=42)
-                return ps
 
         inst = ActionClass()
         assert 'foo' not in inst.dependent_action.params

--- a/ctn_benchmark/tests/test_benchmark.py
+++ b/ctn_benchmark/tests/test_benchmark.py
@@ -1,0 +1,26 @@
+from ctn_benchmark import benchmark, parameters
+
+
+class TestAction(object):
+    def test_specify_and_invoke_action(self):
+        invoked = False
+        class ActionClass(object):
+            @benchmark.Action
+            def dummy_action(self, p):
+                invoked = True
+
+        inst = ActionClass()
+        inst.dummy_action(parameters.ParameterSet())
+
+    def test_handles_dependencies(self):
+        class ActionClass(object):
+            @benchmark.Action
+            def dependency(self, p):
+                return 42
+
+            @benchmark.Action
+            def dependent_action(self, p, dependency):
+                assert dependency == 42
+
+        inst = ActionClass()
+        inst.dependent_action(parameters.ParameterSet())

--- a/ctn_benchmark/tests/test_parameters.py
+++ b/ctn_benchmark/tests/test_parameters.py
@@ -90,6 +90,16 @@ class TestParameterSet(object):
         ps.add_parameter(parameters.Parameter('p', "desc", default=0))
         assert dict(ps) == {'p': 0}
 
+    def test_setting_with_kwargs(self, ps):
+        ps.add_parameter(parameters.Parameter('p1', "desc", default=0))
+        ps.add_parameter(parameters.Parameter('p2', "desc", default=0))
+        ps.set(p1=1, p2=2)
+        assert ps.p1 == 1
+        assert ps.p2 == 2
+
+        with pytest.raises(KeyError):
+            ps.set(nonexistent=3)
+
 
 class TestArgumentParserConversion(object):
     @pytest.fixture()

--- a/ctn_benchmark/tests/test_parameters.py
+++ b/ctn_benchmark/tests/test_parameters.py
@@ -100,6 +100,25 @@ class TestParameterSet(object):
         with pytest.raises(KeyError):
             ps.set(nonexistent=3)
 
+    def test_dict_keys_are_hierarchical(self, ps):
+        ps.add_default("root", root=parameters.ParameterSet())
+        ps.root.add_default("leaf", leaf=2)
+        ps['root.leaf'] = 3
+        assert ps['root.leaf'] == 3
+        del ps['root.leaf']
+        assert ps['root.leaf'] == 2
+
+    def test_provides_flattened_version(self, ps):
+        ps.add_default("foo", foo=1)
+        ps.add_default("root", root=parameters.ParameterSet())
+        ps.root.add_default("leaf", leaf=2)
+        flat = ps.flatten()
+        print flat
+        assert 'foo' in flat
+        assert flat['foo'] == 1
+        assert 'root.leaf' in flat
+        assert flat['root.leaf'] == 2
+
 
 class TestArgumentParserConversion(object):
     @pytest.fixture()


### PR DESCRIPTION
This PR is based on PR #5. It is an attempt to generalize the idea behind ctn_benchmarks and make applicaple to more use cases. For this the `Action` descriptor is introduced (not sure if that's the best name). It allows to mark any method which takes arguments `self, p` as an action. For example:

``` python
from __future__ import print_function
from ctn_benchmark.benchmark import Action

class ClassWithAnAction(object):
    @Action
    def hello(self, p):
        print("Hello world!")
```

The argument `p` is of the type `ctn_benchmark.parameters.ParameterSet` and provides the parameters for the action. For now, we don't make use of any parameters and can call the action like any other method:

``` python
from ctn_benchmark.parameters import ParameterSet

inst = ClassWithAnAction()
inst.hello(parameters.ParameterSet())  # prints "Hello world!"
```

That is not very useful yet. But let us introduce a parameter:

``` python
class ClassWithAnAction(object):
    @Action
    def hello(self, p):
        print("Hello, {name}!".format(p.name))

    @hello.params
    def hello(self, ps):
        ps.add_default("Your name.", name="Terry")
```

The object created with the `@Action` descriptor provides another descriptor to define a function to specify the allowed parameters. (This is analogues to `@property` and `@property_name.setter`.) That function gets a `ParameterSet` object to which we can add new parameters. To invoke the action with the default parameters we can do the following:

``` python
inst = ClassWithAnAction()
inst.hello(inst.hello.all_params)  # prints "Hello, Terry!"
```

The `inst.hello.all_params` attribute returns a `ParameterSet` with all allowed parameters set to their defaults. Of course we can change those parameters:

``` python
p = inst.hello.all_params
p.name = "Jan"
inst.hello(p)  # prints "Hello, Jan!"
```

For convenience it is also possible to set parameters with the keyword arguments style:

``` python
inst.hello(inst.hello.all_params.set(name="Jan"))  # also prints "Hello, Jan!"
```

Invoking and setting parameters from the command line is also easy with `parse_args` which returns the action to invoke and the parameter set. This snippet does the trick:

``` python
from ctn_benchmark.benchmark import parse_args
action, p = parse_args(inst, default='hello')
action(p)
```

Assuming this code in in the file `main.py`, we could to the following:

``` sh
$ python main.py
Hello, Terry!
$ python main.py --name Jan
Hello, Jan!
$ python main.py hello --name Jan
Hello, Jan!
```

Now, let us do something more exciting. Actions support dependencies! Here is an example:

``` python
class WithDependencies(object):
    @Action
    def model(self, p):
        model = ...
        return model

    @Action
    def gui(self, p, model):
        show_gui(model)

    @Action
    def run(self, p, model):
        run_model(model)
```

This would allow to invoke three different actions: model, gui, and run. Both gui and run will automatically invoke the action `model` (because it is listed as a function argument). It is possible to give more than one dependency. Note that dependencies (more precisely all actions) will only be computed once. If a depency appears twice the result from the first execution will be reused.

`inst.action.params` returns the parameter set for this specific action (without dependencies), whereas `inst.action.all_params` returns the parameter set including the parameters of the dependencies (that is what you usually want).

Another feature are pre and post actions. The pre action gets executed before the actual action and computing any of the action's dependencies. The post action will be computed after the action. They are defined like this:

``` python
class Foo(object):
    @Action
    def some_action(self, p):
        pass

    @some_action.pre
    def some_action(self, p):
        pass

    @some_action.post
    def some_action(self, p)
        pass
```

Pre and post actions can also take dependencies.

Finally there are hidden actions. If an action is prefixed with `_`, `parse_args` will ignore it and it cannot be invoked from the command line (and won't show up in the help).

More simple examples of actions can be found in `test_benchmark.py`. More advanced usage in the `Benchmark` and `Benchmark2` classes. The former tries to adhere to the existing API as closely as possible. I think the only difference to before is that there is no `--gui` command line option anymore, but `gui` has to be provided as first argument to invoke the GUI. `Benchmark2` is designed to make more use of actions and changes a number of parameters. For example `show_figs`, `save_figs`, etc. are all actions now (which means they have to be given without `--` as first argument). At the moment the command line allows to invoke only one action at a time, but I am planning to change this to allow multiple actions (so that one could do `save_raw` and `show_figs` again). To try out `Benchmark2`, use `ctn_benchmark/nengo/communication2.py`.

One benefit of `Benchmark2` is that it allows to be explicit about which parameters are for the model, plotting, or evaluation. Also, no check whether `plt` is necessary as it provides the `plot` function which is only called if plots were requested. But it is also possible to do the plotting in `evaluate` if desired. Note that, no `plt` argument is passed. Just use `matplotlib.pyplot`. In the end all figures will be gathered and saved automatically (though I forgot to number the figures if there is more than one, but that is an easy fix).
## Discussion points and to do
- [x] Save figures with number in filename
- [x] I commented out code checking for duplicate parameters because it does not work with repeated dependencies. I have to think more about whether such a check makes sense and what the correct way to implement it would be.
- [ ] Test this with my math TCM for which I am going through this hassle.
- [x] For actions it is more natural to use verbs, whereas for dependencies nouns are more natural. That gives strange naming in some places. It might be best to stick to nouns.
- [x] Allow to invoke multiple actions from the command line.
- [ ] Improve command line help.
