### PR TITLE
Return filename of the data file with simulation results

### DIFF
--- a/ctn_benchmark/benchmark.py
+++ b/ctn_benchmark/benchmark.py
@@ -144,7 +144,7 @@ class Benchmark(object):
         if not os.path.exists(p.data_dir):
             os.mkdir(p.data_dir)
 
-        result['filename'] = fn
+        result['filename'] = fn + '.txt'
 
         fn = os.path.join(p.data_dir, fn)
         if p.save_figs:

--- a/ctn_benchmark/benchmark.py
+++ b/ctn_benchmark/benchmark.py
@@ -152,6 +152,7 @@ class Benchmark(object):
         with open(fn + '.txt', 'w') as f:
             f.write(text)
         print(text)
+        result['filename'] = fn
 
         if p.save_raw:
             db = shelve.open(fn + '.db')

--- a/ctn_benchmark/benchmark.py
+++ b/ctn_benchmark/benchmark.py
@@ -17,8 +17,8 @@ import nengo
 class Benchmark(object):
     def __init__(self):
         self.parser = argparse.ArgumentParser(
-                            description='Nengo benchmark: %s' %
-                                 self.__class__.__name__)
+            description='Nengo benchmark: %s' %
+                        self.__class__.__name__)
         self.param_names = []
         self.hidden_params = []
         self.params()
@@ -109,10 +109,9 @@ class Benchmark(object):
                 import nengo_spinnaker
                 nengo_spinnaker.add_spinnaker_params(model.config)
             for node in model.all_nodes:
-                if (node.size_in == 0 and
-                    node.size_out > 0 and
-                    callable(node.output)):
-                        model.config[node].function_of_time = True
+                if (node.size_in == 0 and node.size_out > 0 and
+                        callable(node.output)):
+                    model.config[node].function_of_time = True
 
         if p.save_figs or p.show_figs:
             plt = matplotlib.pyplot
@@ -134,17 +133,19 @@ class Benchmark(object):
         for k, v in sorted(result.items()):
             text.append('%s = %s' % (k, repr(v)))
 
-
         if plt is not None and not p.hide_overlay:
-            plt.suptitle(fn +'\n' + '\n'.join(text),
+            plt.suptitle(fn + '\n' + '\n'.join(text),
                          fontsize=8)
-            plt.figtext(0.13,0.12,'\n'.join(self.args_text))
+            plt.figtext(0.13, 0.12, '\n'.join(self.args_text))
 
         text = self.args_text + text
         text = '\n'.join(text)
 
         if not os.path.exists(p.data_dir):
             os.mkdir(p.data_dir)
+
+        result['filename'] = fn
+
         fn = os.path.join(p.data_dir, fn)
         if p.save_figs:
             plt.savefig(fn + '.png', dpi=300)
@@ -152,7 +153,6 @@ class Benchmark(object):
         with open(fn + '.txt', 'w') as f:
             f.write(text)
         print(text)
-        result['filename'] = fn
 
         if p.save_raw:
             db = shelve.open(fn + '.db')

--- a/ctn_benchmark/data.py
+++ b/ctn_benchmark/data.py
@@ -3,14 +3,18 @@ import os
 import numpy as np
 
 class Data(object):
-    def __init__(self, path, label=None):
+    def __init__(self, path, filenames=None, label=None):
         self.path = path
         if label is None:
             label = path
         self.label = label
         self.data = []
         if os.path.exists(path):
-            for fn in os.listdir(path):
+            self.filenames = os.listdir(path)
+            if filenames is not None:
+                self.filenames = set.intersection(set(self.filenames),
+                                                  set(filenames))
+            for fn in self.filenames:
                 if fn.endswith('.txt'):
                     with open(os.path.join(path, fn)) as f:
                         text = f.read()

--- a/ctn_benchmark/spa/sequence_routed.py
+++ b/ctn_benchmark/spa/sequence_routed.py
@@ -89,7 +89,7 @@ class SPASequenceRouted(ctn_benchmark.Benchmark):
                  for i in range(len(change_points)-1)]
 
         if plt is not None:
-            plt.plot(times, sim.data[self.probe]
+            plt.plot(times, sim.data[self.probe])
             plt.plot(times[index + 1:], np.where(change!=0,1,0))
 
             for i, peak in enumerate(peaks):

--- a/ctn_benchmark/spa/sequence_routed.py
+++ b/ctn_benchmark/spa/sequence_routed.py
@@ -89,7 +89,7 @@ class SPASequenceRouted(ctn_benchmark.Benchmark):
                  for i in range(len(change_points)-1)]
 
         if plt is not None:
-            plt.plot(times, sim.data[self.probe])
+            plt.plot(times, sim.data[self.probe]
             plt.plot(times[index + 1:], np.where(change!=0,1,0))
 
             for i, peak in enumerate(peaks):


### PR DESCRIPTION
This PR is a first stab at returning the filename of the data file being stored after running a simulation. This is achieved by adding the filename in the list of default items in the dictionary `result` maintained in the `Benchmark.run()`.

I personally found this useful when running tons of simulations and wanting to read only a set of the data files which by default are stored in `./data` using the `Data` class. This seemed to me a clearer solution than always reading the whole directory and extracting the files I'm interested in. 

I'd be happy to improve this further if it is something generally useful.
