### PR TITLE
Force integer division for Python 3

### DIFF
--- a/ctn_benchmark/control/adaptive_bias.py
+++ b/ctn_benchmark/control/adaptive_bias.py
@@ -105,7 +105,7 @@ class AdaptiveBias(ctn_benchmark.Benchmark):
         q = data_p_q[:,0]
         d = data_p_desired[:,0]
 
-        N = len(q) / 2
+        N = len(q) // 2
 
         # find an offset that lines up the data best (this is the delay)
         offsets = []


### PR DESCRIPTION
Was getting `TypeError: slice indices must be integers or None or have an __index__ method` in Python 3. This forces integer division so index variable is not a float.